### PR TITLE
chore: use maven instead of 'java -jar' to run sample

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -89,8 +89,7 @@ commands:
       component: tools
       workingDir: ${PROJECT_SOURCE}/backend
       commandLine: |
-        java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5006,quiet=y \
-        -jar target/backend-1.0.jar
+        mvn spring-boot:run -DskipTests -Drun.jvmArguments='-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5006,quiet=y'
       group:
         kind: run
         isDefault: true
@@ -101,8 +100,7 @@ commands:
       component: tools
       workingDir: ${PROJECT_SOURCE}/frontend
       commandLine: |
-        java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005,quiet=y \
-        -jar target/frontend-1.0.jar
+        mvn spring-boot:run -DskipTests -Drun.jvmArguments='-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005,quiet=y'
       group:
         kind: run
         isDefault: true


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

For both commands to run sample, it's better to use `mvn spring-boot:run` instead of `java -jar`

Solves https://github.com/eclipse/che/issues/20791

To test use
https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com/dashboard/#/https://github.com/vitaliy-guliy/java-guestbook/tree/devfilev2

