### PR TITLE
chore: add missing vscjava.vscode-java-debug extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
     // See https://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-        "redhat.java"
+        "redhat.java",
+        "vscjava.vscode-java-debug"
     ]
 }


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

Add `vscjava.vscode-java-debug` extension to recommendations in `.vscode/extensions.json`.

It was decided not to add `vscjava.vscode-java-test` as the sample does not have any test.

Solves https://github.com/eclipse/che/issues/21644
