### PR TITLE
chore: use https protocol in endpoint

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -10,17 +10,17 @@ components:
       endpoints:
         - name: java-guestbook-backend
           exposure: public
-          protocol: http
+          protocol: https
           targetPort: 8080
 
         - name: java-guestbook
           exposure: public
-          protocol: http
+          protocol: https
           targetPort: 8443
 
         - name: debug
           exposure: none
-          protocol: tcp
+          protocol: https
           targetPort: 5005
 
       volumeMounts:

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -20,7 +20,7 @@ components:
 
         - name: debug
           exposure: none
-          protocol: https
+          protocol: tcp
           targetPort: 5005
 
       volumeMounts:


### PR DESCRIPTION
chore: use https protocol in endpoint
![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2023 12 21-11_36_45](https://github.com/che-samples/java-guestbook/assets/1271546/6b3d8e18-3039-47de-860e-38da8a100b26)

Related issue: https://issues.redhat.com/browse/CRW-5377