### PR TITLE
devfile: set schemaVersion 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: java-guestbook
 components:

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -8,7 +8,7 @@ components:
       memoryLimit: 3Gi
 
       endpoints:
-        - name: java-guestbook-backend
+        - name: backend
           exposure: public
           protocol: https
           targetPort: 8080

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -45,7 +45,7 @@ components:
         value: password
 
       endpoints:
-        - name: java-guestbook-mongodb
+        - name: mongodb
           exposure: none
           protocol: tcp
           targetPort: 27017

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -13,7 +13,7 @@ components:
           protocol: https
           targetPort: 8080
 
-        - name: java-guestbook
+        - name: frontend
           exposure: public
           protocol: https
           targetPort: 8443


### PR DESCRIPTION
Set devfile schemaVersion: 2.2.2

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2024 01 31-15_50_10](https://github.com/che-samples/java-guestbook/assets/1271546/cb10319f-640c-49fa-8c6e-450f3069ab8d)


Related issue: https://github.com/eclipse/che/issues/21985

